### PR TITLE
Use SMAppService if macOS >= 13 and improve performance slightly

### DIFF
--- a/Hot/Classes/ThermalLog.swift
+++ b/Hot/Classes/ThermalLog.swift
@@ -187,6 +187,7 @@ public class ThermalLog: NSObject
                 self.temperature = NSNumber( value: temp )
             }
 			
+#if arch(x86_64)
 			let status = UnsafeMutablePointer<Unmanaged<CFDictionary>?>.allocate(capacity: 3)
 			let result = IOPMCopyCPUPowerStatus(status)
 			
@@ -200,6 +201,7 @@ public class ThermalLog: NSObject
 			}
 			
 			status.deallocate()
+#endif
 
             self.refreshing = false
 

--- a/Hot/Classes/ThermalLog.swift
+++ b/Hot/Classes/ThermalLog.swift
@@ -194,9 +194,9 @@ public class ThermalLog: NSObject
 			   let data = status.move()?.takeUnretainedValue() {
 				let dataMap = data as NSDictionary
 				
-				self.speedLimit		= (dataMap[kIOPMCPUPowerLimitProcessorSpeedKey]! as! Double) as NSNumber
-				self.availableCPUs	= (dataMap[kIOPMCPUPowerLimitProcessorCountKey]! as! Int)    as NSNumber
-				self.schedulerLimit	= (dataMap[kIOPMCPUPowerLimitSchedulerTimeKey]!  as! Double) as NSNumber
+				self.speedLimit		= dataMap[kIOPMCPUPowerLimitProcessorSpeedKey] as? NSNumber
+				self.availableCPUs	= dataMap[kIOPMCPUPowerLimitProcessorCountKey] as? NSNumber
+				self.schedulerLimit	= dataMap[kIOPMCPUPowerLimitSchedulerTimeKey]  as? NSNumber
 			}
 			
 			status.deallocate()


### PR DESCRIPTION
- With macOS 13, Apple introduced a drastically simplified way of launching an app at login, [SMAppService](https://developer.apple.com/documentation/servicemanagement/smappservice?language=objc). This PR encapsulates the new API into an availability check in order to preserve downward compatibility.

- thermal stats are currently read by executing `/usr/bin/pmset` and parsing the result, which is inefficient and fragile. This PR calls [IOPMCopyCPUPowerStatus](https://developer.apple.com/documentation/iokit/1557079-iopmcopycpupowerstatus) directly just like [pmset does](https://github.com/apple-open-source/macos/blob/c988f225e157430c39b6e32250ec521d9678effe/PowerManagement/pmset/pmset.m#L4177) which mainly results in more stable code but also a ~3% performance gain on x86_64 or ~6% on arm64e.
