### PR TITLE
fix: Resize host view after graph height changes so menu re-measures

### DIFF
--- a/Hot/Classes/InfoViewController.swift
+++ b/Hot/Classes/InfoViewController.swift
@@ -152,7 +152,22 @@ public class InfoViewController: NSViewController
             self.graphView?.addData( speed: 100, temperature: self.temperature )
         }
 
-        self.graphViewHeight.constant = self.graphView?.canDisplay ?? false ? 100 : 0
+        let newGraphHeight: CGFloat = self.graphView?.canDisplay ?? false ? 100 : 0
+
+        if self.graphViewHeight.constant != newGraphHeight
+        {
+            self.graphViewHeight.constant = newGraphHeight
+
+            // The InfoViewController's view is hosted inside an NSMenuItem (see
+            // ApplicationDelegate.applicationDidFinishLaunching). NSMenu measures
+            // the custom view once and does not observe later Auto Layout changes,
+            // so when the graph height flips from 0 -> 100 the menu item's host
+            // frame stays at the original (smaller) size and clips the top of the
+            // graph. Force a layout pass and propagate the new fitting size to the
+            // view's frame so the menu picks up the change.
+            self.view.layoutSubtreeIfNeeded()
+            self.view.frame.size = self.view.fittingSize
+        }
 
         self.onUpdate?()
     }


### PR DESCRIPTION
## Summary

The temperature graph in the menu bar dropdown is clipped at the top: only the legend (orange dot + "Temperature" label) is visible at the bottom of the graph box, the sparkline above it gets cut off. Other rows in the same `InfoViewController` stack view (Thermal Pressure, Temperature value, etc.) can also be clipped depending on layout state.

| Before (bug) | After (fix) |
| :---: | :---: |
| ![Clipped graph in the Hot dropdown — only the bottom legend is visible](https://raw.githubusercontent.com/pggpgg/Hot/pr-assets/bug-clipped-graph.png) | ![Hot dropdown rendering correctly with full graph and other rows visible](https://raw.githubusercontent.com/pggpgg/Hot/pr-assets/fixed-graph.png) |

> _Note: the two screenshots were taken in different system appearances (Dark mode for "before", Light mode for "after"), which is why the menu chrome and graph background look different. `GraphView` uses `NSColor.controlTextColor` for its rounded-rect background, and that's a dynamic system color that resolves differently between Dark and Light mode. No color-related code was changed by this PR._

## Root cause

`InfoViewController.view` is installed as a custom view on an `NSMenuItem` in `ApplicationDelegate.applicationDidFinishLaunching`:

```swift
self.menu.item( withTag: 1 )?.view = infoViewController.view
```

`NSMenu` measures the custom view's frame once at this point and caches the result for the menu item's host. It does **not** observe later Auto Layout changes to the view's intrinsic size.

`viewDidLoad` initializes `graphViewHeight.constant = 0`, so the view is initially short. A couple of seconds later, once two temperature samples have been collected, `update()` does:

```swift
self.graphViewHeight.constant = self.graphView?.canDisplay ?? false ? 100 : 0
```

Auto Layout grows the view to its new height, but the menu item's host frame stays at the original (smaller) value. The bottom-anchored portions of the graph (drawn at `rect.origin.y` in unflipped coords — the orange dot and "Temperature" label) remain visible, while the top of the graph — including the sparkline — is clipped off by the menu item's container.

## Fix

After the constraint change in `update()`:

1. Detect that the constraint actually changed (avoids re-laying out every refresh tick).
2. Call `view.layoutSubtreeIfNeeded()` to flush the pending Auto Layout pass.
3. Set `view.frame.size = view.fittingSize` to nudge `NSMenu` to re-measure the custom view's host item with the new size.

This is the minimal change that gets the menu to respect the dynamic content size.

## Test plan

- [x] Build patched Hot.app, launch, open the dropdown after ~4 seconds (enough time for two temperature samples to populate the graph). Graph is now fully visible.
- [x] Close and re-open the dropdown several times — graph renders correctly each time.
- [x] Verified on macOS 26.5 with Xcode 26.5 (Apple Silicon, MacBook Air).

🤖 Generated with [Claude Code](https://claude.com/claude-code)